### PR TITLE
exception correction

### DIFF
--- a/epson_printer/epsonprinter.py
+++ b/epson_printer/epsonprinter.py
@@ -124,7 +124,7 @@ class PrintableImage:
         pixels = np.vstack((pixels, extra_pixels))
         h += extra_rows
         nb_stripes = h / 24
-        pixels = pixels.reshape(nb_stripes, 24, w).swapaxes(1, 2).reshape(-1, 8)
+        pixels = pixels.reshape(int(nb_stripes), 24, w).swapaxes(1, 2).reshape(-1, 8)
 
         nh = int(w / 256)
         nl = w % 256


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals    
  File "/media/alejandro/9eafe6e5-7fd3-4333-bea8-513fc3fd6c09/workon/test/python-epson-printer/epson_printer/testpage.py", line 41, in <module>
    printer.print_image_from_file("logo.png")           
  File "epson_printer/epsonprinter.py", line 279, in print_image_from_file
    printable_image = PrintableImage.from_image(image)
  File "epson_printer/epsonprinter.py", line 135, in from_image
    pixels = pixels.reshape(nb_stripes, 24, w).swapaxes(1, 2).reshape(-1, 8)
TypeError: 'float' object cannot be interpreted as an index